### PR TITLE
Added the ability to customize the color of the WASD menu options using config.

### DIFF
--- a/API/Class/Config.cs
+++ b/API/Class/Config.cs
@@ -37,7 +37,16 @@ internal static class ConfigManager
 
     public class WasdMenuSettings
     {
-        public bool FreezePlayer { get; set; }
+        public string TitleColor { get; set; } = string.Empty;
+        public string ScrollUpDownKeyColor { get; set; } = string.Empty;
+        public string SelectKeyColor { get; set; } = string.Empty;
+        public string PrevKeyColor { get; set; } = string.Empty;
+        public string ExitKeyColor { get; set; } = string.Empty;
+        public string SelectedOptionColor { get; set; } = string.Empty;
+        public string OptionColor { get; set; } = string.Empty;
+        public string DisabledOptionColor { get; set; } = string.Empty;
+        public string ArrowColor { get; set; } = string.Empty;
+        public bool FreezePlayer { get; set; } = false;
     }
 
     public class ScreenMenu
@@ -98,6 +107,15 @@ internal static class ConfigManager
         Config.Sound.ScrollDown = soundTable["ScrollDown"].ToString()!;
 
         TomlTable wasdTable = (TomlTable)model["WasdMenu"];
+        Config.WasdMenu.TitleColor = wasdTable["TitleColor"].ToString()!;
+        Config.WasdMenu.ScrollUpDownKeyColor = wasdTable["ScrollUpDownKeyColor"].ToString()!;
+        Config.WasdMenu.SelectKeyColor = wasdTable["SelectKeyColor"].ToString()!;
+        Config.WasdMenu.PrevKeyColor = wasdTable["PrevKeyColor"].ToString()!;
+        Config.WasdMenu.ExitKeyColor = wasdTable["ExitKeyColor"].ToString()!;
+        Config.WasdMenu.SelectedOptionColor = wasdTable["SelectedOptionColor"].ToString()!;
+        Config.WasdMenu.OptionColor = wasdTable["OptionColor"].ToString()!;
+        Config.WasdMenu.DisabledOptionColor = wasdTable["DisabledOptionColor"].ToString()!;
+        Config.WasdMenu.ArrowColor = wasdTable["ArrowColor"].ToString()!;
         Config.WasdMenu.FreezePlayer = bool.Parse(wasdTable["FreezePlayer"]?.ToString() ?? "false");
 
         TomlTable screenTable = (TomlTable)model["ScreenMenu"];

--- a/API/Class/Config.cs
+++ b/API/Class/Config.cs
@@ -1,4 +1,9 @@
 ﻿using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core.Translations;
+using CounterStrikeSharp.API.Modules.Utils;
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using Tomlyn;
 using Tomlyn.Model;
@@ -10,10 +15,62 @@ internal static class ConfigManager
 {
     public class Cfg
     {
-        public ButtonsKey Buttons { get; set; } = new();
+        public ButtonsKey Buttons { get; set; } = new()
+        {
+            ScrollUp = "W",
+            ScrollDown = "S",
+            Select = "E",
+            Prev = "Shift",
+            Exit = "Tab"
+        };
         public Sound Sound { get; set; } = new();
-        public WasdMenuSettings WasdMenu { get; set; } = new();
-        public ScreenMenu ScreenMenu { get; set; } = new();
+        public ChatMenuSettings ChatMenu { get; set; } = new()
+        {
+            TitleColor = ChatColors.Yellow,
+            EnabledColor = ChatColors.Green,
+            DisabledColor = ChatColors.Grey,
+            PrevPageColor = ChatColors.Yellow,
+            NextPageColor = ChatColors.Yellow,
+            ExitColor = ChatColors.Red
+        };
+        public CenterHtmlMenuSettings CenterHtmlMenu { get; set; } = new()
+        {
+            TitleColor = "yellow",
+            EnabledColor = "green",
+            DisabledColor = "grey",
+            PrevPageColor = "yellow",
+            NextPageColor = "yellow",
+            ExitColor = "red",
+            InlinePageOptions = true,
+            MaxTitleLength = 0,
+            MaxOptionLength = 0
+        };
+        public WasdMenuSettings WasdMenu { get; set; } = new()
+        {
+            TitleColor = "green",
+            ScrollUpDownKeyColor = "cyan",
+            SelectKeyColor = "green",
+            PrevKeyColor = "orange",
+            ExitKeyColor = "red",
+            SelectedOptionColor = "orange",
+            OptionColor = "white",
+            DisabledOptionColor = "grey",
+            ArrowColor = "purple",
+            FreezePlayer = false
+        };
+        public ScreenMenu ScreenMenu { get; set; } = new()
+        {
+            TextColor = "orange",
+            PositionX = -5.5f,
+            PositionY = 0.0f,
+            Background = true,
+            BackgroundHeight = 0,
+            BackgroundWidth = 0.2f,
+            Font = "Arial Bold",
+            Size = 32,
+            FreezePlayer = false,
+            ShowResolutionsOption = true
+        };
         public Dictionary<string, Resolution> Resolutions { get; set; } = [];
         public Dictionary<string, Dictionary<string, string>> Lang { get; set; } = [];
     }
@@ -33,6 +90,29 @@ internal static class ConfigManager
         public string Exit { get; set; } = string.Empty;
         public string ScrollUp { get; set; } = string.Empty;
         public string ScrollDown { get; set; } = string.Empty;
+    }
+
+    public class ChatMenuSettings
+    {
+        public char TitleColor { get; set; }
+        public char EnabledColor { get; set; }
+        public char DisabledColor { get; set; }
+        public char PrevPageColor { get; set; }
+        public char NextPageColor { get; set; }
+        public char ExitColor { get; set; }
+    }
+
+    public class CenterHtmlMenuSettings
+    {
+        public string TitleColor { get; set; } = string.Empty;
+        public string EnabledColor { get; set; } = string.Empty;
+        public string DisabledColor { get; set; } = string.Empty;
+        public string PrevPageColor { get; set; } = string.Empty;
+        public string NextPageColor { get; set; } = string.Empty;
+        public string ExitColor { get; set; } = string.Empty;
+        public bool InlinePageOptions { get; set; }
+        public int MaxTitleLength { get; set; }
+        public int MaxOptionLength { get; set; }
     }
 
     public class WasdMenuSettings
@@ -93,68 +173,87 @@ internal static class ConfigManager
         string configText = File.ReadAllText(ConfigFilePath);
         TomlTable model = Toml.ToModel(configText);
 
-        TomlTable buttons = (TomlTable)model["Buttons"];
-        Config.Buttons.ScrollUp = buttons["ScrollUp"].ToString()!;
-        Config.Buttons.ScrollDown = buttons["ScrollDown"].ToString()!;
-        Config.Buttons.Select = buttons["Select"].ToString()!;
-        Config.Buttons.Prev = buttons["Prev"].ToString()!;
-        Config.Buttons.Exit = buttons["Exit"].ToString()!;
+        Console.WriteLine($"LOADİNG CONFİG");
 
-        TomlTable soundTable = (TomlTable)model["Sound"];
-        Config.Sound.Select = soundTable["Select"].ToString()!;
-        Config.Sound.Exit = soundTable["Exit"].ToString()!;
-        Config.Sound.ScrollUp = soundTable["ScrollUp"].ToString()!;
-        Config.Sound.ScrollDown = soundTable["ScrollDown"].ToString()!;
+        model.SetIfPresent("Buttons.ScrollUp", (string value) => Config.Buttons.ScrollUp = value);
+        model.SetIfPresent("Buttons.ScrollDown", (string value) => Config.Buttons.ScrollDown = value);
+        model.SetIfPresent("Buttons.Select", (string value) => Config.Buttons.Select = value);
+        model.SetIfPresent("Buttons.Prev", (string value) => Config.Buttons.Prev = value);
+        model.SetIfPresent("Buttons.Exit", (string value) => Config.Buttons.Exit = value);
 
-        TomlTable wasdTable = (TomlTable)model["WasdMenu"];
-        Config.WasdMenu.TitleColor = wasdTable["TitleColor"].ToString()!;
-        Config.WasdMenu.ScrollUpDownKeyColor = wasdTable["ScrollUpDownKeyColor"].ToString()!;
-        Config.WasdMenu.SelectKeyColor = wasdTable["SelectKeyColor"].ToString()!;
-        Config.WasdMenu.PrevKeyColor = wasdTable["PrevKeyColor"].ToString()!;
-        Config.WasdMenu.ExitKeyColor = wasdTable["ExitKeyColor"].ToString()!;
-        Config.WasdMenu.SelectedOptionColor = wasdTable["SelectedOptionColor"].ToString()!;
-        Config.WasdMenu.OptionColor = wasdTable["OptionColor"].ToString()!;
-        Config.WasdMenu.DisabledOptionColor = wasdTable["DisabledOptionColor"].ToString()!;
-        Config.WasdMenu.ArrowColor = wasdTable["ArrowColor"].ToString()!;
-        Config.WasdMenu.FreezePlayer = bool.Parse(wasdTable["FreezePlayer"]?.ToString() ?? "false");
+        model.SetIfPresent("Sound.Select", (string value) => Config.Sound.Select = value);
+        model.SetIfPresent("Sound.Exit", (string value) => Config.Sound.Exit = value);
+        model.SetIfPresent("Sound.ScrollUp", (string value) => Config.Sound.ScrollUp = value);
+        model.SetIfPresent("Sound.ScrollDown", (string value) => Config.Sound.ScrollDown = value);
 
-        TomlTable screenTable = (TomlTable)model["ScreenMenu"];
-        Config.ScreenMenu.TextColor = screenTable["TextColor"].ToString()!;
-        Config.ScreenMenu.PositionX = float.Parse(screenTable["PositionX"].ToString()!);
-        Config.ScreenMenu.PositionY = float.Parse(screenTable["PositionY"].ToString()!);
-        Config.ScreenMenu.Background = bool.Parse(screenTable["Background"].ToString()!);
-        Config.ScreenMenu.BackgroundHeight = float.Parse(screenTable["BackgroundHeight"].ToString()!);
-        Config.ScreenMenu.BackgroundWidth = float.Parse(screenTable["BackgroundWidth"].ToString()!);
-        Config.ScreenMenu.Font = screenTable["Font"].ToString()!;
-        Config.ScreenMenu.Size = int.Parse(screenTable["Size"].ToString()!);
-        Config.ScreenMenu.FreezePlayer = bool.Parse(screenTable["FreezePlayer"].ToString()!);
-        Config.ScreenMenu.ShowResolutionsOption = bool.Parse(screenTable["ShowResolutionsOption"].ToString()!);
+        model.SetIfPresent("ChatMenu.TitleColor", (string value) => Config.ChatMenu.TitleColor = value.GetChatColor());
+        model.SetIfPresent("ChatMenu.EnabledColor", (string value) => Config.ChatMenu.EnabledColor = value.GetChatColor());
+        model.SetIfPresent("ChatMenu.DisabledColor", (string value) => Config.ChatMenu.DisabledColor = value.GetChatColor());
+        model.SetIfPresent("ChatMenu.PrevPageColor", (string value) => Config.ChatMenu.PrevPageColor = value.GetChatColor());
+        model.SetIfPresent("ChatMenu.NextPageColor", (string value) => Config.ChatMenu.NextPageColor = value.GetChatColor());
+        model.SetIfPresent("ChatMenu.ExitColor", (string value) => Config.ChatMenu.ExitColor = value.GetChatColor());
 
-        TomlTable resolutionsTable = (TomlTable)model["Resolutions"];
-        foreach (KeyValuePair<string, object> resolution in resolutionsTable)
+        model.SetIfPresent("CenterHtmlMenu.TitleColor", (string value) => Config.CenterHtmlMenu.TitleColor = value);
+        model.SetIfPresent("CenterHtmlMenu.EnabledColor", (string value) => Config.CenterHtmlMenu.EnabledColor = value);
+        model.SetIfPresent("CenterHtmlMenu.DisabledColor", (string value) => Config.CenterHtmlMenu.DisabledColor = value);
+        model.SetIfPresent("CenterHtmlMenu.PrevPageColor", (string value) => Config.CenterHtmlMenu.PrevPageColor = value);
+        model.SetIfPresent("CenterHtmlMenu.NextPageColor", (string value) => Config.CenterHtmlMenu.NextPageColor = value);
+        model.SetIfPresent("CenterHtmlMenu.ExitColor", (string value) => Config.CenterHtmlMenu.ExitColor = value);
+        model.SetIfPresent("CenterHtmlMenu.InlinePageOptions", (bool value) => Config.CenterHtmlMenu.InlinePageOptions = value);
+        model.SetIfPresent("CenterHtmlMenu.MaxTitleLength", (int value) => Config.CenterHtmlMenu.MaxTitleLength = value);
+        model.SetIfPresent("CenterHtmlMenu.MaxOptionLength", (int value) => Config.CenterHtmlMenu.MaxOptionLength = value);
+
+        model.SetIfPresent("WasdMenu.TitleColor", (string value) => Config.WasdMenu.TitleColor = value);
+        model.SetIfPresent("WasdMenu.ScrollUpDownKeyColor", (string value) => Config.WasdMenu.ScrollUpDownKeyColor = value);
+        model.SetIfPresent("WasdMenu.SelectKeyColor", (string value) => Config.WasdMenu.SelectKeyColor = value);
+        model.SetIfPresent("WasdMenu.PrevKeyColor", (string value) => Config.WasdMenu.PrevKeyColor = value);
+        model.SetIfPresent("WasdMenu.ExitKeyColor", (string value) => Config.WasdMenu.ExitKeyColor = value);
+        model.SetIfPresent("WasdMenu.SelectedOptionColor", (string value) => Config.WasdMenu.SelectedOptionColor = value);
+        model.SetIfPresent("WasdMenu.OptionColor", (string value) => Config.WasdMenu.OptionColor = value);
+        model.SetIfPresent("WasdMenu.DisabledOptionColor", (string value) => Config.WasdMenu.DisabledOptionColor = value);
+        model.SetIfPresent("WasdMenu.ArrowColor", (string value) => Config.WasdMenu.ArrowColor = value);
+        model.SetIfPresent("WasdMenu.FreezePlayer", (bool value) => Config.WasdMenu.FreezePlayer = value);
+
+        model.SetIfPresent("ScreenMenu.TextColor", (string value) => Config.ScreenMenu.TextColor = value);
+        model.SetIfPresent("ScreenMenu.PositionX", (float value) => Config.ScreenMenu.PositionX = value);
+        model.SetIfPresent("ScreenMenu.PositionY", (float value) => Config.ScreenMenu.PositionY = value);
+        model.SetIfPresent("ScreenMenu.Background", (bool value) => Config.ScreenMenu.Background = value);
+        model.SetIfPresent("ScreenMenu.BackgroundHeight", (float value) => Config.ScreenMenu.BackgroundHeight = value);
+        model.SetIfPresent("ScreenMenu.BackgroundWidth", (float value) => Config.ScreenMenu.BackgroundWidth = value);
+        model.SetIfPresent("ScreenMenu.Font", (string value) => Config.ScreenMenu.Font = value);
+        model.SetIfPresent("ScreenMenu.Size", (int value) => Config.ScreenMenu.Size = value);
+        model.SetIfPresent("ScreenMenu.FreezePlayer", (bool value) => Config.ScreenMenu.FreezePlayer = value);
+        model.SetIfPresent("ScreenMenu.ShowResolutionsOption", (bool value) => Config.ScreenMenu.ShowResolutionsOption = value);
+
+        model.SetIfExist("Resolutions", (TomlTable table) =>
         {
-            if (resolution.Value is TomlTable innerTable)
+            foreach (var item in table)
             {
-                Config.Resolutions[resolution.Key] = new Resolution()
+                if (item.Value is TomlTable innerTable)
                 {
-                    PositionX = float.Parse(innerTable["PositionX"].ToString()!),
-                    PositionY = float.Parse(innerTable["PositionY"].ToString()!)
-                };
-            }
-        }
-
-        TomlTable langTable = (TomlTable)model["Lang"];
-        foreach (KeyValuePair<string, object> lang in langTable)
-        {
-            if (lang.Value is TomlTable innerTable)
-            {
-                Dictionary<string, string> innerDict = Config.Lang.GetValueOrDefault(lang.Key) ?? (Config.Lang[lang.Key] = []);
-
-                foreach (KeyValuePair<string, object> item in innerTable)
-                {
-                    innerDict[item.Key] = item.Value?.ToString() ?? string.Empty;
+                    Config.Resolutions[item.Key] = new Resolution
+                    {
+                        PositionX = innerTable.GetValue<float>("PositionX"),
+                        PositionY = innerTable.GetValue<float>("PositionY")
+                    };
                 }
             }
-        }
+        });
+
+        model.SetIfExist("Lang", (TomlTable table) =>
+        {
+            foreach (var item in table)
+            {
+                if (item.Value is TomlTable innerTable)
+                {
+                    var innerDict = new Dictionary<string, string>();
+                    foreach (var innerItem in innerTable)
+                    {
+                        innerDict[innerItem.Key] = innerItem.Value?.ToString() ?? string.Empty;
+                    }
+                    Config.Lang[item.Key] = innerDict;
+                }
+            }
+        });
     }
 }

--- a/API/Class/Config.cs
+++ b/API/Class/Config.cs
@@ -46,7 +46,7 @@ internal static class ConfigManager
         public string OptionColor { get; set; } = string.Empty;
         public string DisabledOptionColor { get; set; } = string.Empty;
         public string ArrowColor { get; set; } = string.Empty;
-        public bool FreezePlayer { get; set; } = false;
+        public bool FreezePlayer { get; set; }
     }
 
     public class ScreenMenu

--- a/API/Class/Config.cs
+++ b/API/Class/Config.cs
@@ -173,8 +173,6 @@ internal static class ConfigManager
         string configText = File.ReadAllText(ConfigFilePath);
         TomlTable model = Toml.ToModel(configText);
 
-        Console.WriteLine($"LOADİNG CONFİG");
-
         model.SetIfPresent("Buttons.ScrollUp", (string value) => Config.Buttons.ScrollUp = value);
         model.SetIfPresent("Buttons.ScrollDown", (string value) => Config.Buttons.ScrollDown = value);
         model.SetIfPresent("Buttons.Select", (string value) => Config.Buttons.Select = value);

--- a/API/Class/Library.cs
+++ b/API/Class/Library.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using Tomlyn.Model;
 using static CS2MenuManager.API.Class.ConfigManager;
 
 namespace CS2MenuManager.API.Class;
@@ -192,5 +193,41 @@ internal static partial class Library
             result.Append($"</{tagStack.Pop()}>");
 
         return result.ToString();
+    }
+
+    public static void SetIfPresent<T>(this TomlTable table, string key, Action<T> setter)
+    {
+        var split = key.Split('.', StringSplitOptions.TrimEntries);
+
+        if (table.TryGetValue(split[0], out var innerValue) && innerValue is TomlTable innerTable)
+        {
+            if (innerTable.TryGetValue(split[1], out var value))
+            {
+                T typedValue = (T)Convert.ChangeType(value, typeof(T));
+                setter(typedValue);
+            }
+        }
+    }
+
+    public static void SetIfExist(this TomlTable table, string key, Action<TomlTable> setter)
+    {
+        if (table.TryGetValue(key, out var value) && value is TomlTable innerTable)
+        {
+            setter(innerTable);
+        }
+    }
+
+    public static T? GetValue<T>(this TomlTable table, string key)
+    {
+        if (table.TryGetValue(key, out var value))
+        {
+            return (T)Convert.ChangeType(value, typeof(T));
+        }
+        return default;
+    }
+
+    public static char GetChatColor(this string colorName)
+    {
+        return (char)typeof(ChatColors).GetField(colorName)?.GetValue(null)!;
     }
 }

--- a/API/Menu/CenterHtmlMenu.cs
+++ b/API/Menu/CenterHtmlMenu.cs
@@ -19,47 +19,47 @@ public class CenterHtmlMenu(string title, BasePlugin plugin) : BaseMenu(title, p
     /// <summary>
     /// Gets or sets the color of the title.
     /// </summary>
-    public string TitleColor { get; set; } = Config.CenterHtmlMenu.TitleColor;
+    public string TitleColor = Config.CenterHtmlMenu.TitleColor;
 
     /// <summary>
     /// Gets or sets the color of enabled items.
     /// </summary>
-    public string EnabledColor { get; set; } = Config.CenterHtmlMenu.EnabledColor;
+    public string EnabledColor = Config.CenterHtmlMenu.EnabledColor;
 
     /// <summary>
     /// Gets or sets the color of disabled items.
     /// </summary>
-    public string DisabledColor { get; set; } = Config.CenterHtmlMenu.DisabledColor;
+    public string DisabledColor = Config.CenterHtmlMenu.DisabledColor;
 
     /// <summary>
     /// Gets or sets the color of the previous page button.
     /// </summary>
-    public string PrevPageColor { get; set; } = Config.CenterHtmlMenu.PrevPageColor;
+    public string PrevPageColor = Config.CenterHtmlMenu.PrevPageColor;
 
     /// <summary>
     /// Gets or sets the color of the next page button.
     /// </summary>
-    public string NextPageColor { get; set; } = Config.CenterHtmlMenu.NextPageColor;
+    public string NextPageColor = Config.CenterHtmlMenu.NextPageColor;
 
     /// <summary>
     /// Gets or sets the color of the close button.
     /// </summary>
-    public string ExitColor { get; set; } = Config.CenterHtmlMenu.ExitColor;
+    public string ExitColor = Config.CenterHtmlMenu.ExitColor;
 
     /// <summary>
     /// Gets or sets a value indicating whether page options are displayed inline.
     /// </summary>
-    public bool InlinePageOptions { get; set; } = Config.CenterHtmlMenu.InlinePageOptions;
+    public bool InlinePageOptions = Config.CenterHtmlMenu.InlinePageOptions;
 
     /// <summary>
     /// Gets or sets the maximum length of the title.
     /// </summary>
-    public int MaxTitleLength { get; set; } = Config.CenterHtmlMenu.MaxTitleLength;
+    public int MaxTitleLength = Config.CenterHtmlMenu.MaxTitleLength;
 
     /// <summary>
     /// Gets or sets the maximum length of each option.
     /// </summary>
-    public int MaxOptionLength { get; set; } = Config.CenterHtmlMenu.MaxOptionLength;
+    public int MaxOptionLength = Config.CenterHtmlMenu.MaxOptionLength;
 
     /// <summary>
     /// Displays the menu to the specified player for a specified duration.

--- a/API/Menu/CenterHtmlMenu.cs
+++ b/API/Menu/CenterHtmlMenu.cs
@@ -5,6 +5,7 @@ using CS2MenuManager.API.Interface;
 using System.Text;
 using static CounterStrikeSharp.API.Core.Listeners;
 using static CS2MenuManager.API.Class.Library;
+using static CS2MenuManager.API.Class.ConfigManager;
 
 namespace CS2MenuManager.API.Menu;
 
@@ -18,47 +19,47 @@ public class CenterHtmlMenu(string title, BasePlugin plugin) : BaseMenu(title, p
     /// <summary>
     /// Gets or sets the color of the title.
     /// </summary>
-    public string TitleColor { get; set; } = "yellow";
+    public string TitleColor { get; set; } = Config.CenterHtmlMenu.TitleColor;
 
     /// <summary>
     /// Gets or sets the color of enabled items.
     /// </summary>
-    public string EnabledColor { get; set; } = "green";
+    public string EnabledColor { get; set; } = Config.CenterHtmlMenu.EnabledColor;
 
     /// <summary>
     /// Gets or sets the color of disabled items.
     /// </summary>
-    public string DisabledColor { get; set; } = "grey";
+    public string DisabledColor { get; set; } = Config.CenterHtmlMenu.DisabledColor;
 
     /// <summary>
     /// Gets or sets the color of the previous page button.
     /// </summary>
-    public string PrevPageColor { get; set; } = "yellow";
+    public string PrevPageColor { get; set; } = Config.CenterHtmlMenu.PrevPageColor;
 
     /// <summary>
     /// Gets or sets the color of the next page button.
     /// </summary>
-    public string NextPageColor { get; set; } = "yellow";
+    public string NextPageColor { get; set; } = Config.CenterHtmlMenu.NextPageColor;
 
     /// <summary>
     /// Gets or sets the color of the close button.
     /// </summary>
-    public string ExitColor { get; set; } = "red";
+    public string ExitColor { get; set; } = Config.CenterHtmlMenu.ExitColor;
 
     /// <summary>
     /// Gets or sets a value indicating whether page options are displayed inline.
     /// </summary>
-    public bool InlinePageOptions { get; set; } = true;
+    public bool InlinePageOptions { get; set; } = Config.CenterHtmlMenu.InlinePageOptions;
 
     /// <summary>
     /// Gets or sets the maximum length of the title.
     /// </summary>
-    public int MaxTitleLength { get; set; } = 0;
+    public int MaxTitleLength { get; set; } = Config.CenterHtmlMenu.MaxTitleLength;
 
     /// <summary>
     /// Gets or sets the maximum length of each option.
     /// </summary>
-    public int MaxOptionLength { get; set; } = 0;
+    public int MaxOptionLength { get; set; } = Config.CenterHtmlMenu.MaxOptionLength;
 
     /// <summary>
     /// Displays the menu to the specified player for a specified duration.

--- a/API/Menu/ChatMenu.cs
+++ b/API/Menu/ChatMenu.cs
@@ -2,6 +2,7 @@
 using CounterStrikeSharp.API.Modules.Utils;
 using CS2MenuManager.API.Class;
 using CS2MenuManager.API.Enum;
+using static CS2MenuManager.API.Class.ConfigManager;
 
 namespace CS2MenuManager.API.Menu;
 
@@ -15,32 +16,32 @@ public class ChatMenu(string title, BasePlugin plugin) : BaseMenu(title, plugin)
     /// <summary>
     /// Gets or sets the color of the title.
     /// </summary>
-    public char TitleColor { get; set; } = ChatColors.Yellow;
+    public char TitleColor { get; set; } = Config.ChatMenu.TitleColor;
 
     /// <summary>
     /// Gets or sets the color of enabled items.
     /// </summary>
-    public char EnabledColor { get; set; } = ChatColors.Green;
+    public char EnabledColor { get; set; } = Config.ChatMenu.EnabledColor;
 
     /// <summary>
     /// Gets or sets the color of disabled items.
     /// </summary>
-    public char DisabledColor { get; set; } = ChatColors.Grey;
+    public char DisabledColor { get; set; } = Config.ChatMenu.DisabledColor;
 
     /// <summary>
     /// Gets or sets the color of the previous page button.
     /// </summary>
-    public char PrevPageColor { get; set; } = ChatColors.Yellow;
+    public char PrevPageColor { get; set; } = Config.ChatMenu.PrevPageColor;
 
     /// <summary>
     /// Gets or sets the color of the next page button.
     /// </summary>
-    public char NextPageColor { get; set; } = ChatColors.Yellow;
+    public char NextPageColor { get; set; } = Config.ChatMenu.NextPageColor;
 
     /// <summary>
     /// Gets or sets the color of the close button.
     /// </summary>
-    public char ExitColor { get; set; } = ChatColors.Red;
+    public char ExitColor { get; set; } = Config.ChatMenu.ExitColor;
 
     /// <summary>
     /// Displays the menu to the specified player for a specified duration.

--- a/API/Menu/ChatMenu.cs
+++ b/API/Menu/ChatMenu.cs
@@ -16,32 +16,32 @@ public class ChatMenu(string title, BasePlugin plugin) : BaseMenu(title, plugin)
     /// <summary>
     /// Gets or sets the color of the title.
     /// </summary>
-    public char TitleColor { get; set; } = Config.ChatMenu.TitleColor;
+    public char TitleColor = Config.ChatMenu.TitleColor;
 
     /// <summary>
     /// Gets or sets the color of enabled items.
     /// </summary>
-    public char EnabledColor { get; set; } = Config.ChatMenu.EnabledColor;
+    public char EnabledColor = Config.ChatMenu.EnabledColor;
 
     /// <summary>
     /// Gets or sets the color of disabled items.
     /// </summary>
-    public char DisabledColor { get; set; } = Config.ChatMenu.DisabledColor;
+    public char DisabledColor = Config.ChatMenu.DisabledColor;
 
     /// <summary>
     /// Gets or sets the color of the previous page button.
     /// </summary>
-    public char PrevPageColor { get; set; } = Config.ChatMenu.PrevPageColor;
+    public char PrevPageColor = Config.ChatMenu.PrevPageColor;
 
     /// <summary>
     /// Gets or sets the color of the next page button.
     /// </summary>
-    public char NextPageColor { get; set; } = Config.ChatMenu.NextPageColor;
+    public char NextPageColor = Config.ChatMenu.NextPageColor;
 
     /// <summary>
     /// Gets or sets the color of the close button.
     /// </summary>
-    public char ExitColor { get; set; } = Config.ChatMenu.ExitColor;
+    public char ExitColor = Config.ChatMenu.ExitColor;
 
     /// <summary>
     /// Displays the menu to the specified player for a specified duration.

--- a/API/Menu/ScreenMenu.cs
+++ b/API/Menu/ScreenMenu.cs
@@ -23,42 +23,42 @@ public class ScreenMenu(string title, BasePlugin plugin) : BaseMenu(title, plugi
     /// <summary>
     /// Gets or sets the color of the text.
     /// </summary>
-    public string TextColor { get; set; } = Config.ScreenMenu.TextColor;
+    public string TextColor = Config.ScreenMenu.TextColor;
 
     /// <summary>
     /// Gets or sets a value indicating whether the menu has a background.
     /// </summary>
-    public bool Background { get; set; } = Config.ScreenMenu.Background;
+    public bool Background = Config.ScreenMenu.Background;
 
     /// <summary>
     /// Gets or sets the height of the background.
     /// </summary>
-    public float BackgroundHeight { get; set; } = Config.ScreenMenu.BackgroundHeight;
+    public float BackgroundHeight = Config.ScreenMenu.BackgroundHeight;
 
     /// <summary>
     /// Gets or sets the width of the background.
     /// </summary>
-    public float BackgroundWidth { get; set; } = Config.ScreenMenu.BackgroundWidth;
+    public float BackgroundWidth = Config.ScreenMenu.BackgroundWidth;
 
     /// <summary>
     /// Gets or sets the font used for the text.
     /// </summary>
-    public string Font { get; set; } = Config.ScreenMenu.Font;
+    public string Font = Config.ScreenMenu.Font;
 
     /// <summary>
     /// Gets or sets the size of the text.
     /// </summary>
-    public int Size { get; set; } = Config.ScreenMenu.Size;
+    public int Size = Config.ScreenMenu.Size;
 
     /// <summary>
     /// Gets or sets a value indicating whether the player is frozen while the menu is open.
     /// </summary>
-    public bool FreezePlayer { get; set; } = Config.ScreenMenu.FreezePlayer;
+    public bool FreezePlayer = Config.ScreenMenu.FreezePlayer;
 
     /// <summary>
     /// Gets or sets a value indicating whether the menu shows a resolutions option.
     /// </summary>
-    public bool ShowResolutionsOption { get; set; } = Config.ScreenMenu.ShowResolutionsOption;
+    public bool ShowResolutionsOption = Config.ScreenMenu.ShowResolutionsOption;
 
     /// <summary>
     /// Displays the menu to the specified player for a specified duration.

--- a/API/Menu/WasdMenu.cs
+++ b/API/Menu/WasdMenu.cs
@@ -20,52 +20,52 @@ public class WasdMenu(string title, BasePlugin plugin) : BaseMenu(title, plugin)
     /// <summary>
     /// Gets or sets the color of the title.
     /// </summary>
-    public string TitleColor => Config.WasdMenu.TitleColor;
+    public string TitleColor = Config.WasdMenu.TitleColor;
 
     /// <summary>
     /// Gets or sets the color of the scroll up/down buttons.
     /// </summary>
-    public string ScrollUpDownKeyColor => Config.WasdMenu.ScrollUpDownKeyColor;
+    public string ScrollUpDownKeyColor = Config.WasdMenu.ScrollUpDownKeyColor;
 
     /// <summary>
     /// Gets or sets the color of the select button.
     /// </summary>
-    public string SelectKeyColor => Config.WasdMenu.SelectKeyColor;
+    public string SelectKeyColor = Config.WasdMenu.SelectKeyColor;
 
     /// <summary>
     /// Gets or sets the color of the prev button.
     /// </summary>
-    public string PrevKeyColor => Config.WasdMenu.PrevKeyColor;
+    public string PrevKeyColor = Config.WasdMenu.PrevKeyColor;
 
     /// <summary>
     /// Gets or sets the color of the exit button.
     /// </summary>
-    public string ExitKeyColor => Config.WasdMenu.ExitKeyColor;
+    public string ExitKeyColor = Config.WasdMenu.ExitKeyColor;
 
     /// <summary>
     /// Gets or sets the color of the selected option.
     /// </summary>
-    public string SelectedOptionColor => Config.WasdMenu.SelectedOptionColor;
+    public string SelectedOptionColor = Config.WasdMenu.SelectedOptionColor;
 
     /// <summary>
     /// Gets or sets the color of the options.
     /// </summary>
-    public string OptionColor => Config.WasdMenu.OptionColor;
+    public string OptionColor = Config.WasdMenu.OptionColor;
 
     /// <summary>
     /// Gets or sets the color of the disabled options.
     /// </summary>
-    public string DisabledOptionColor => Config.WasdMenu.DisabledOptionColor;
+    public string DisabledOptionColor = Config.WasdMenu.DisabledOptionColor;
 
     /// <summary>
     /// Gets or sets the color of the arrows.
     /// </summary>
-    public string ArrowColor => Config.WasdMenu.ArrowColor;
+    public string ArrowColor = Config.WasdMenu.ArrowColor;
 
     /// <summary>
     /// Gets or sets a value indicating whether the player is frozen while the menu is open.
     /// </summary>
-    public bool FreezePlayer => Config.WasdMenu.FreezePlayer;
+    public bool FreezePlayer = Config.WasdMenu.FreezePlayer;
 
     /// <summary>
     /// Displays the menu to the specified player for a specified duration.

--- a/API/Menu/WasdMenu.cs
+++ b/API/Menu/WasdMenu.cs
@@ -65,7 +65,7 @@ public class WasdMenu(string title, BasePlugin plugin) : BaseMenu(title, plugin)
     /// <summary>
     /// Gets or sets a value indicating whether the player is frozen while the menu is open.
     /// </summary>
-    public bool FreezePlayer { get; set; } = Config.WasdMenu.FreezePlayer;
+    public bool FreezePlayer => Config.WasdMenu.FreezePlayer;
 
     /// <summary>
     /// Displays the menu to the specified player for a specified duration.

--- a/API/Menu/WasdMenu.cs
+++ b/API/Menu/WasdMenu.cs
@@ -20,47 +20,47 @@ public class WasdMenu(string title, BasePlugin plugin) : BaseMenu(title, plugin)
     /// <summary>
     /// Gets or sets the color of the title.
     /// </summary>
-    public string TitleColor { get; set; } = "green";
+    public string TitleColor => Config.WasdMenu.TitleColor;
 
     /// <summary>
     /// Gets or sets the color of the scroll up/down buttons.
     /// </summary>
-    public string ScrollUpDownKeyColor { get; set; } = "cyan";
+    public string ScrollUpDownKeyColor => Config.WasdMenu.ScrollUpDownKeyColor;
 
     /// <summary>
     /// Gets or sets the color of the select button.
     /// </summary>
-    public string SelectKeyColor { get; set; } = "green";
+    public string SelectKeyColor => Config.WasdMenu.SelectKeyColor;
 
     /// <summary>
     /// Gets or sets the color of the prev button.
     /// </summary>
-    public string PrevKeyColor { get; set; } = "orange";
+    public string PrevKeyColor => Config.WasdMenu.PrevKeyColor;
 
     /// <summary>
     /// Gets or sets the color of the exit button.
     /// </summary>
-    public string ExitKeyColor { get; set; } = "red";
+    public string ExitKeyColor => Config.WasdMenu.ExitKeyColor;
 
     /// <summary>
     /// Gets or sets the color of the selected option.
     /// </summary>
-    public string SelectedOptionColor { get; set; } = "orange";
+    public string SelectedOptionColor => Config.WasdMenu.SelectedOptionColor;
 
     /// <summary>
     /// Gets or sets the color of the options.
     /// </summary>
-    public string OptionColor { get; set; } = "white";
+    public string OptionColor => Config.WasdMenu.OptionColor;
 
     /// <summary>
     /// Gets or sets the color of the disabled options.
     /// </summary>
-    public string DisabledOptionColor { get; set; } = "grey";
+    public string DisabledOptionColor => Config.WasdMenu.DisabledOptionColor;
 
     /// <summary>
     /// Gets or sets the color of the arrows.
     /// </summary>
-    public string ArrowColor { get; set; } = "purple";
+    public string ArrowColor => Config.WasdMenu.ArrowColor;
 
     /// <summary>
     /// Gets or sets a value indicating whether the player is frozen while the menu is open.

--- a/CS2MenuManager.sln
+++ b/CS2MenuManager.sln
@@ -1,0 +1,29 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35013.160
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CS2MenuManager", "CS2MenuManager.csproj", "{6E4C86F8-8E8E-4E22-9815-339EED9BCC7E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6E4C86F8-8E8E-4E22-9815-339EED9BCC7E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E4C86F8-8E8E-4E22-9815-339EED9BCC7E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E4C86F8-8E8E-4E22-9815-339EED9BCC7E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E4C86F8-8E8E-4E22-9815-339EED9BCC7E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3FB0AFB3-316A-4D08-9CB3-63CFD720AC3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3FB0AFB3-316A-4D08-9CB3-63CFD720AC3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3FB0AFB3-316A-4D08-9CB3-63CFD720AC3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3FB0AFB3-316A-4D08-9CB3-63CFD720AC3D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A9FC1EA6-0A7A-4B04-B5A3-0FB63C74290A}
+	EndGlobalSection
+EndGlobal

--- a/config.toml
+++ b/config.toml
@@ -11,17 +11,36 @@ Exit = ""
 ScrollUp = ""
 ScrollDown = ""
 
+[ChatMenu]
+TitleColor = "Yellow"
+EnabledColor = "Green"
+DisabledColor = "Grey"
+PrevPageColor = "Yellow"
+NextPageColor = "Yellow"
+ExitColor = "Red"
+
+[CenterHtmlMenu]
+TitleColor = "Yellow"
+EnabledColor = "Green"
+DisabledColor = "Grey"
+PrevPageColor = "Yellow"
+NextPageColor = "Yellow"
+ExitColor = "Red"
+InlinePageOptions = true
+MaxTitleLength = 0
+MaxOptionLength = 0
+
 [WasdMenu]
-TitleColor = "green"
-ScrollUpDownKeyColor = "cyan"
-SelectKeyColor = "green"
-PrevKeyColor = "orange"
-ExitKeyColor = "red"
-SelectedOptionColor = "orange"
-OptionColor = "white"
-DisabledOptionColor = "grey"
-ArrowColor = "purple"
-FreezePlayer = true
+TitleColor = "Green"
+ScrollUpDownKeyColor = "Cyan"
+SelectKeyColor = "Green"
+PrevKeyColor = "Orange"
+ExitKeyColor = "Red"
+SelectedOptionColor = "Orange"
+OptionColor = "White"
+DisabledOptionColor = "Grey"
+ArrowColor = "Purple"
+FreezePlayer = false
 
 [ScreenMenu]
 TextColor = "orange"
@@ -82,27 +101,3 @@ PrevKey = "{0} - Előző"
 ExitKey = "{0} - Kilépés"
 SelectResolution = "Felbontás kiválasztása"
 WarnDisabledItem = "{Red}Nem tudod {Grey}ezt az opciót választani."
-
-[Lang.zh-Hans]
-Prev = "上一页"
-Next = "下一页"
-Exit = "退出"
-Disabled = "禁用"
-Scroll = "[{0}/{1}] 滚动"
-Select = "[{0}] 选择"
-PrevKey = "{0} - 上一页"
-ExitKey = "{0} - 退出"
-SelectResolution = "选择分辨率"
-WarnDisabledItem = "{Grey}你 {Red}无法 {Grey}进入此选项."
-
-[Lang.zh-Hant]
-Prev = "上一頁"
-Next = "下一頁"
-Exit = "退出"
-Disabled = "禁用"
-Scroll = "[{0}/{1}] 滾動"
-Select = "[{0}] 選擇"
-PrevKey = "{0} - 上一頁"
-ExitKey = "{0} - 退出"
-SelectResolution = "選擇解析度"
-WarnDisabledItem = "{Grey}你 {Red}無法 {Grey}進入此選項."

--- a/config.toml
+++ b/config.toml
@@ -21,7 +21,7 @@ SelectedOptionColor = "orange"
 OptionColor = "white"
 DisabledOptionColor = "grey"
 ArrowColor = "purple"
-FreezePlayer = false
+FreezePlayer = true
 
 [ScreenMenu]
 TextColor = "orange"

--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,15 @@ ScrollUp = ""
 ScrollDown = ""
 
 [WasdMenu]
+TitleColor = "green"
+ScrollUpDownKeyColor = "cyan"
+SelectKeyColor = "green"
+PrevKeyColor = "orange"
+ExitKeyColor = "red"
+SelectedOptionColor = "orange"
+OptionColor = "white"
+DisabledOptionColor = "grey"
+ArrowColor = "purple"
 FreezePlayer = false
 
 [ScreenMenu]


### PR DESCRIPTION
Added customize options to change the WASD menu color.

> [WasdMenu]
TitleColor = "green"
ScrollUpDownKeyColor = "cyan"
SelectKeyColor = "green"
PrevKeyColor = "orange"
ExitKeyColor = "red"
SelectedOptionColor = "orange"
OptionColor = "white"
DisabledOptionColor = "grey"
ArrowColor = "purple"
FreezePlayer = false

![416f47f3-608d-49d8-82f6-76bf624bd84d](https://github.com/user-attachments/assets/bb5fe533-05e0-409e-8bc8-49b628da15bc)
![fd71556c-72d8-42f6-a3b5-08a54b9d7994](https://github.com/user-attachments/assets/66935fcb-3ec7-4633-84a5-0cf927f4e3ab)
