### PR TITLE
Fix ambiguous call causing compile to fail

### DIFF
--- a/CS2MenuManager/API/Class/Library.cs
+++ b/CS2MenuManager/API/Class/Library.cs
@@ -215,7 +215,7 @@ internal static partial class Library
 
                     if (!tag.StartsWith("</", StringComparison.Ordinal))
                     {
-                        string tagName = tag.Split([' ', '>', '/'], StringSplitOptions.RemoveEmptyEntries)[0].TrimStart('<');
+                        string tagName = tag.Split(new[] { ' ', '>', '/' }, StringSplitOptions.RemoveEmptyEntries)[0].TrimStart('<');
                         if (!tag.EndsWith("/>", StringComparison.Ordinal) && !tagName.StartsWith('!'))
                             tagStack.Push(tagName);
                     }


### PR DESCRIPTION
While compiling locally, I received the error:
`CS2MenuManager\CS2MenuManager\API\Class\Library.cs(217,46): error CS0121: The call is ambiguous between the following methods or properties: 'string.Split(char[]?, StringSplitOptions)' and 'string.Split(string?, StringSplitOptions)'`

This change to the `tag.Split` resolved it.